### PR TITLE
Add set of APIs to set/get the global state

### DIFF
--- a/apps/client/src/App.tsx
+++ b/apps/client/src/App.tsx
@@ -74,7 +74,7 @@ export default function App() {
 
     const getEdDSAPCD = useCallback(() => {
         const url = getWithoutProvingUrl(
-            String(process.env.PCDPASS_URL),
+            process.env.PCDPASS_URL as string,
             window.location.origin + "/popup",
             EdDSAPCDPackage.name
         )

--- a/apps/client/src/App.tsx
+++ b/apps/client/src/App.tsx
@@ -1,17 +1,44 @@
 import { EdDSAPCDPackage } from "@pcd/eddsa-pcd"
 import { getWithoutProvingUrl, openPassportPopup, usePassportPopupMessages } from "@pcd/passport-interface"
-import { useCallback, useEffect } from "react"
+import React from "react"
+import { useCallback, useEffect, useState } from "react"
 
 /**
- * It takes a message signed with your EdDSA key containing a
- * color and uses it as the background color of the app page
- * if the signature is valid.
+ * This component consumes a message signed with an EdDSA key. If you have provided a valid signature, 
+ * it uses the color as the background of the web app page. This background is preserved as long as 
+ * you do not consume a signature on a different colour.
  */
 export default function App() {
     const [passportPCDString] = usePassportPopupMessages()
+    const [bgColor, setBgColor] = useState<string>()
 
     useEffect(() => {
-        ;(async () => {
+        // Get the color extracted from the latest valid message signed with an EdDSA key.
+        const getLatestConsumedColor = async () => {
+            const response = await fetch(`http://localhost:${process.env.SERVER_PORT}/color/get`, {
+                method: 'GET',
+                mode: 'cors'
+            })
+
+            if (!!response.ok) {
+                const body = await response.json()
+                setBgColor(body.color)
+            }
+        }
+
+        getLatestConsumedColor()
+    }, [])
+
+    useEffect(() => {
+        // Update the background color accordingly to color change.
+        const appElement = document.getElementById("app")!
+
+        appElement.style.backgroundColor = `#${bgColor}`
+    }, [bgColor])
+
+    useEffect(() => {
+        ; (async () => {
+            // @ts-ignore
             await EdDSAPCDPackage.init({})
 
             if (passportPCDString) {
@@ -20,13 +47,24 @@ export default function App() {
                 const pcd = await EdDSAPCDPackage.deserialize(serializedPCD)
 
                 if (await EdDSAPCDPackage.verify(pcd)) {
+                    // Get PCD claim (color).
                     const color = pcd.claim.message[0].toString(16)
 
-                    const appElement = document.getElementById("app")
+                    // Store consumed color on the server.
+                    await fetch(`http://localhost:${process.env.SERVER_PORT}/color/set`, {
+                        method: 'POST',
+                        mode: 'cors',
+                        headers: {
+                            "Content-Type": "application/json"
+                        },
+                        body: JSON.stringify({
+                            color: color
+                        }),
+                    })
 
                     alert(`The signature is valid, #${color} will be used as a background color!`)
 
-                    appElement.style.backgroundColor = `#${color}`
+                    setBgColor(color)
                 } else {
                     alert(`The signature is not valid!`)
                 }
@@ -36,7 +74,7 @@ export default function App() {
 
     const getEdDSAPCD = useCallback(() => {
         const url = getWithoutProvingUrl(
-            process.env.PCDPASS_URL,
+            String(process.env.PCDPASS_URL),
             window.location.origin + "/popup",
             EdDSAPCDPackage.name
         )
@@ -44,5 +82,5 @@ export default function App() {
         openPassportPopup("/popup", url)
     }, [])
 
-    return <button onClick={getEdDSAPCD}>Get PCD signature</button>
+    return <><button onClick={getEdDSAPCD}>Get PCD signature</button></>
 }

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -8,10 +8,12 @@
     "start": "ts-node src/index.ts"
   },
   "dependencies": {
+    "cors": "^2.8.5",
     "dotenv": "^16.3.1",
     "express": "^4.18.2"
   },
   "devDependencies": {
+    "@types/cors": "^2.8.13",
     "@types/dotenv": "^8.2.0",
     "@types/express": "^4.17.17",
     "@types/node": "^20.5.7",

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1,13 +1,58 @@
 import express, { Express, Request, Response } from 'express';
 import dotenv from "dotenv"
+import cors from "cors"
 
 dotenv.config({ path: `${process.cwd()}/../../.env` })
 
 const app: Express = express();
 const port = process.env.SERVER_PORT || 3000;
 
+// Middlewares.
+app.use(express.json())
+app.use(express.urlencoded({ extended: true }))
+app.use(cors())
+
 app.get('/', (req: Request, res: Response) => {
   res.send('Express + TypeScript Server');
+});
+
+// Store a color on a NodeJS environment variable.
+app.post('/color/set', (req: Request, res: Response) => {
+  try {
+    if (!req.body.color) {
+      console.error(`[ERROR] No color specified!`)
+
+      res.status(400).send()
+    } else {
+      // Set the color on NodeJS `COLOR` environment variable.
+      process.env['COLOR'] = req.body.color;
+
+      console.debug(`[OKAY] color has been set to ${process.env.COLOR}`)
+
+      res.status(200).send()
+    }
+  } catch (error: any) {
+    console.error(`[ERROR] ${error}`)
+    res.send(500)
+  }
+});
+
+// Get the color stored on the NodeJS environment variable.
+app.get('/color/get', (req: Request, res: Response) => {
+  try {
+    if (!process.env.COLOR) {
+      console.error(`[ERROR] No color has been saved yet!`)
+
+      res.status(404).send()
+    } else {
+      console.debug(`[OKAY] color ${process.env.COLOR} has been successfully sent`)
+
+      res.json({ color: process.env.COLOR }).status(200);
+    }
+  } catch (error: any) {
+    console.error(`[ERROR] ${error}`)
+    res.send(500)
+  }
 });
 
 app.listen(port, () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2284,6 +2284,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/cors@npm:^2.8.13":
+  version: 2.8.13
+  resolution: "@types/cors@npm:2.8.13"
+  dependencies:
+    "@types/node": "*"
+  checksum: 7ef197ea19d2e5bf1313b8416baa6f3fd6dd887fd70191da1f804f557395357dafd8bc8bed0ac60686923406489262a7c8a525b55748f7b2b8afa686700de907
+  languageName: node
+  linkType: hard
+
 "@types/debug@npm:^4.1.7":
   version: 4.1.8
   resolution: "@types/debug@npm:4.1.8"
@@ -3367,6 +3376,16 @@ __metadata:
   version: 0.5.0
   resolution: "cookie@npm:0.5.0"
   checksum: 1f4bd2ca5765f8c9689a7e8954183f5332139eb72b6ff783d8947032ec1fdf43109852c178e21a953a30c0dd42257828185be01b49d1eb1a67fd054ca588a180
+  languageName: node
+  linkType: hard
+
+"cors@npm:^2.8.5":
+  version: 2.8.5
+  resolution: "cors@npm:2.8.5"
+  dependencies:
+    object-assign: ^4
+    vary: ^1
+  checksum: ced838404ccd184f61ab4fdc5847035b681c90db7ac17e428f3d81d69e2989d2b680cc254da0e2554f5ed4f8a341820a1ce3d1c16b499f6e2f47a1b9b07b5006
   languageName: node
   linkType: hard
 
@@ -5478,6 +5497,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"object-assign@npm:^4":
+  version: 4.1.1
+  resolution: "object-assign@npm:4.1.1"
+  checksum: fcc6e4ea8c7fe48abfbb552578b1c53e0d194086e2e6bbbf59e0a536381a292f39943c6e9628af05b5528aa5e3318bb30d6b2e53cadaf5b8fe9e12c4b69af23f
+  languageName: node
+  linkType: hard
+
 "object-inspect@npm:^1.9.0":
   version: 1.12.3
   resolution: "object-inspect@npm:1.12.3"
@@ -6090,9 +6116,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "server@workspace:apps/server"
   dependencies:
+    "@types/cors": ^2.8.13
     "@types/dotenv": ^8.2.0
     "@types/express": ^4.17.17
     "@types/node": ^20.5.7
+    cors: ^2.8.5
     dotenv: ^16.3.1
     express: ^4.18.2
     ts-node: ^10.9.1
@@ -6647,7 +6675,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vary@npm:~1.1.2":
+"vary@npm:^1, vary@npm:~1.1.2":
   version: 1.1.2
   resolution: "vary@npm:1.1.2"
   checksum: ae0123222c6df65b437669d63dfa8c36cee20a504101b2fcd97b8bf76f91259c17f9f2b4d70a1e3c6bbcee7f51b28392833adb6b2770b23b01abec84e369660b


### PR DESCRIPTION
This PR adds two endpoints to the server to set and retrieve the last message (aka color) present in the last PCD consumed by the client. The color is saved in an environment variable on NodeJS to keep things minimal (no db).

__TODOs__
- [x] Add get / post endpoints on server
- [x] Add missing middlewares (json + cors)
- [x] Adapt client logic